### PR TITLE
Add initial test suite

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,7 @@ aiofiles
 jinja2
 starlette
 uvicorn
+
+# Testing
+pytest
+requests

--- a/scripts/test
+++ b/scripts/test
@@ -1,3 +1,9 @@
 #!/bin/sh -ex
 
-echo "Passed"
+if [ "${CONTINUOUS_INTEGRATION}" = "true" ]; then
+    BIN_PATH=""
+else
+    BIN_PATH="venv/bin/"
+fi
+
+PYTHONPATH=. ${BIN_PATH}pytest tests

--- a/tests/test_homepage.py
+++ b/tests/test_homepage.py
@@ -1,0 +1,9 @@
+from app import app
+from starlette.testclient import TestClient
+
+
+def test_app():
+    client = TestClient(app)
+    response = client.get('/')
+    assert response.status_code == 200
+    assert response.template.name == 'index.html'


### PR DESCRIPTION
Add a single test for making a request to the homepage, and ensuring the correct template is loaded.

Related:

* We would like to switch to `httpx` for test cases.
* We should probably open an issue against the ASGI spec wrt. messaging "template" info for test client type usages like this. (Allowing for `response.template.name` and `response.template.context` interfaces.)
* We should add support to `httpx` for including template info on responses.