### PR TITLE
Use envvars for app config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 venv/
+.env

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import uvicorn
 
 
 config = Config()
-DEBUG = config('DEBUG', cast=bool, default=False)
+DEBUG = config("DEBUG", cast=bool, default=False)
 
 templates = Jinja2Templates(directory="templates")
 

--- a/app.py
+++ b/app.py
@@ -1,13 +1,17 @@
 from starlette.applications import Starlette
+from starlette.config import Config
 from starlette.staticfiles import StaticFiles
 from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
 import uvicorn
 
 
+config = Config()
+DEBUG = config('DEBUG', cast=bool, default=False)
+
 templates = Jinja2Templates(directory="templates")
 
-app = Starlette(debug=True)
+app = Starlette(debug=DEBUG)
 app.mount("/static", StaticFiles(directory="statics"), name="static")
 
 

--- a/scripts/install
+++ b/scripts/install
@@ -8,6 +8,10 @@ else
     BIN_PATH="venv/bin/"
 fi
 
+if ! [ -f .env ] ; then
+    echo "DEBUG=true" > .env
+fi
+
 if [ "$1" = "--update" ]; then
     ${BIN_PATH}pip install -U -r requirements.base
     scripts/freeze

--- a/scripts/run
+++ b/scripts/run
@@ -1,3 +1,4 @@
 #!/bin/sh -ex
 
-venv/bin/uvicorn app:app --reload
+PATH=venv/bin:${PATH}
+heroku local


### PR DESCRIPTION
Closes #15.

* Switch to `heroku local` for running the app, so that our `.env` file is being loaded consistently.
* Populate the `.env` file on first install, but have it in `.gitignore` so that it isn't commited.
* Load the envionment in `app.py` and use it to populate the application `debug` flag.