### PR TITLE
Sentry integration

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,15 +3,26 @@ from starlette.config import Config
 from starlette.staticfiles import StaticFiles
 from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
+from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
+import sentry_sdk
 import uvicorn
 
 
 config = Config()
 DEBUG = config("DEBUG", cast=bool, default=False)
+SENTRY_DSN = config("DEBUG", cast=str, default="")
+
+if SENTRY_DSN:
+    sentry_sdk.init(dsn=SENTRY_DSN)
+
 
 templates = Jinja2Templates(directory="templates")
 
 app = Starlette(debug=DEBUG)
+
+if SENTRY_DSN:
+    app.add_middleware(SentryAsgiMiddleware)
+
 app.mount("/static", StaticFiles(directory="statics"), name="static")
 
 

--- a/requirements.base
+++ b/requirements.base
@@ -10,8 +10,9 @@ aiofiles==0.4.*
 jinja2==2.*
 starlette==0.12.*
 uvicorn==0.9.*
+sentry-sdk==0.12.*
 
 # Testing (For consistency we still want to install these to production tho.)
-black==19.*
+black
 pytest==5.*
 requests==2.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ py==1.8.0
 pyparsing==2.4.2
 pytest==5.2.0
 requests==2.22.0
+sentry-sdk==0.12.3
 six==1.12.0
 starlette==0.12.9
 toml==0.10.0

--- a/scripts/install
+++ b/scripts/install
@@ -13,8 +13,9 @@ if ! [ -f .env ] ; then
 fi
 
 if [ "$1" = "--update" ]; then
+    rm -f requirements.txt
     ${BIN_PATH}pip install -U -r requirements.base
-    scripts/freeze
+    ${BIN_PATH}pip freeze > requirements.txt
 else
     ${BIN_PATH}pip install -U -r requirements.txt
 fi


### PR DESCRIPTION
Closes #7

Notes:

* Set SENTRY_DNS in production using `heroku config:set SENTRY_DNS=...`.
* Show config with `heroku config`.