### PR TITLE
Set sentry release

### DIFF
--- a/source/app.py
+++ b/source/app.py
@@ -4,12 +4,14 @@ from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from source import settings
+import subprocess
 import sentry_sdk
 import uvicorn
 
 
 if settings.SENTRY_DSN:
-    sentry_sdk.init(dsn=settings.SENTRY_DSN)
+    git_revision = subprocess.run(["git", "rev-parse", "HEAD"]).stdout
+    sentry_sdk.init(dsn=settings.SENTRY_DSN, release=git_revision)
 
 
 templates = Jinja2Templates(directory="templates")

--- a/source/app.py
+++ b/source/app.py
@@ -4,14 +4,12 @@ from starlette.responses import HTMLResponse
 from starlette.templating import Jinja2Templates
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 from source import settings
-import subprocess
 import sentry_sdk
 import uvicorn
 
 
 if settings.SENTRY_DSN:
-    git_revision = subprocess.run(["git", "rev-parse", "HEAD"]).stdout
-    sentry_sdk.init(dsn=settings.SENTRY_DSN, release=git_revision)
+    sentry_sdk.init(dsn=settings.SENTRY_DSN, release=settings.GIT_REVISION)
 
 
 templates = Jinja2Templates(directory="templates")
@@ -27,7 +25,8 @@ app.mount("/static", StaticFiles(directory="statics"), name="static")
 @app.route("/")
 async def homepage(request):
     template = "index.html"
-    context = {"request": request}
+    context = {"request": request, "settings": settings}
+    print(settings.DEBUG, settings.GIT_REVISION)
     return templates.TemplateResponse(template, context)
 
 

--- a/source/settings.py
+++ b/source/settings.py
@@ -1,6 +1,10 @@
 from starlette.config import Config
+import subprocess
 
 config = Config()
 
 DEBUG = config("DEBUG", cast=bool, default=False)
 SENTRY_DSN = config("SENTRY_DSN", cast=str, default="")
+GIT_REVISION = subprocess.run(
+    ["git", "rev-parse", "HEAD"], capture_output=True
+).stdout.decode("ascii")

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,6 +7,7 @@
   <div class="jumbotron">
     <div class="container">
       <h1 class="display-3">Hello, world!</h1>
+      <p>Revision: {{ settings.GIT_REVISION }}</p>
       <p>This is a template for a simple marketing or informational website. It includes a large callout called a jumbotron and three supporting pieces of content. Use it as a starting point to create something more unique.</p>
       <p><a class="btn btn-primary btn-lg" href="#" role="button">Learn more &raquo;</a></p>
     </div>


### PR DESCRIPTION
Show the git revision on the homepage.
Configure sentry to have a release indicated by the git sha (makes sense since we're deploying to Heroku on pushes, so the git sha is a unique deploy reference for us.)
Hoping this will be enough to configure sentry's release tracking.