### PR TITLE
Pass release version to Sentry

### DIFF
--- a/source/app.py
+++ b/source/app.py
@@ -9,7 +9,7 @@ import uvicorn
 
 
 if settings.SENTRY_DSN:
-    sentry_sdk.init(dsn=settings.SENTRY_DSN, release=settings.GIT_REVISION)
+    sentry_sdk.init(dsn=settings.SENTRY_DSN, release=settings.RELEASE_VERSION)
 
 
 templates = Jinja2Templates(directory="templates")
@@ -26,7 +26,6 @@ app.mount("/static", StaticFiles(directory="statics"), name="static")
 async def homepage(request):
     template = "index.html"
     context = {"request": request, "settings": settings}
-    print(settings.DEBUG, settings.GIT_REVISION)
     return templates.TemplateResponse(template, context)
 
 

--- a/source/settings.py
+++ b/source/settings.py
@@ -5,6 +5,7 @@ config = Config()
 
 DEBUG = config("DEBUG", cast=bool, default=False)
 SENTRY_DSN = config("SENTRY_DSN", cast=str, default="")
-GIT_REVISION = subprocess.run(
-    ["git", "rev-parse", "HEAD"], capture_output=True
-).stdout.decode("ascii")
+
+# Heroku Dyno Metadata, enabled with `heroku labs:enable runtime-dyno-metadata`
+# See https://devcenter.heroku.com/articles/dyno-metadata for more info.
+RELEASE_VERSION = config("HEROKU_RELEASE_VERSION", cast=str, default="<local dev>")

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,7 +7,7 @@
   <div class="jumbotron">
     <div class="container">
       <h1 class="display-3">Hello, world!</h1>
-      <p>Revision: {{ settings.GIT_REVISION }}</p>
+      <p>Release version: {{ settings.RELEASE_VERSION }}</p>
       <p>This is a template for a simple marketing or informational website. It includes a large callout called a jumbotron and three supporting pieces of content. Use it as a starting point to create something more unique.</p>
       <p><a class="btn btn-primary btn-lg" href="#" role="button">Learn more &raquo;</a></p>
     </div>


### PR DESCRIPTION
The git revision isn't available on Heroku, so needed to install [the "Dyno Metadata" extenstion](https://devcenter.heroku.com/articles/dyno-metadata) to provide additional environment info, including the Heroku release version.

We're now passing Heroku's release version string into Sentry, so in order to populate Sentry's releases info.

