### PR TITLE
Add support for column ordering

### DIFF
--- a/source/datasource.py
+++ b/source/datasource.py
@@ -1,5 +1,17 @@
 # Data for 2017 UK general election.
 # From https://www.electoralcommission.org.uk/who-we-are-and-what-we-do/elections-and-referendums
+from dataclasses import dataclass
+
+
+@dataclass
+class DataItem:
+    pk: int
+    constituency: str
+    surname: str
+    first_name: str
+    party: str
+    votes: int
+
 
 DATA_SOURCE = [
     ("Aldershot", "WALLACE", "Donna Maria", "Green Party", "1090"),
@@ -4346,4 +4358,14 @@ DATA_SOURCE = [
     ("Ynys Môn", "TURNER", "James Nicholas", "UKIP", "624"),
 ]
 
-DATA_SOURCE_WITH_INDEX = [(idx,) + line for idx, line in enumerate(DATA_SOURCE)]
+DATA_SOURCE_WITH_INDEX = [
+    DataItem(
+        pk=idx + 1,
+        constituency=line[0],
+        surname=line[1],
+        first_name=line[2],
+        party=line[3],
+        votes=int(line[4]),
+    )
+    for idx, line in enumerate(DATA_SOURCE)
+]

--- a/source/ordering.py
+++ b/source/ordering.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass
+from starlette.datastructures import URL, QueryParams
+import typing
+
+
+@dataclass
+class ColumnControl:
+    id: str
+    text: str
+    url: URL = None
+    is_forward_sorted: bool = False
+    is_reverse_sorted: bool = False
+
+    @property
+    def is_sorted(self):
+        return self.is_forward_sorted or self.is_reverse_sorted
+
+
+def get_ordering(
+    url: URL, allowed_column_ids: typing.Sequence[str]
+) -> typing.Tuple[typing.Optional[str], bool]:
+    """
+    Determine a column ordering based on the URL query string.
+    Returned as a tuple of (ordering, is_reverse).
+    """
+    query_params = QueryParams(url.query)
+
+    ordering = query_params.get("order", default="")
+    order_column = ordering.lstrip("-")
+    order_reverse = ordering.startswith("-")
+    if order_column not in allowed_column_ids:
+        return None, False
+    return order_column, order_reverse
+
+
+def sort_by_ordering(
+    items: list, column: typing.Optional[str], is_reverse: bool
+) -> list:
+    """
+    Sort a data set by an ordering column.
+    """
+    if column is None:
+        return items
+
+    sort_key = lambda item: (getattr(item, column), item.pk)
+    return sorted(items, key=sort_key, reverse=is_reverse)
+
+
+def get_column_controls(
+    url: URL, names: typing.List[str], column: typing.Optional[str], is_reverse: bool
+) -> typing.List[ColumnControl]:
+    controls = [ColumnControl(id="", text="#")]
+    for name in names:
+        column_id = name.lower().replace(" ", "_")
+
+        if column != column_id:
+            # Column is not selected. Link URL to forward search.
+            linked_url = url.include_query_params(order=column_id)
+        elif not is_reverse:
+            # Column is selected as a forward search. Link URL to reverse search.
+            linked_url = url.include_query_params(order="-" + column_id)
+        else:
+            # Column is selected as a reverse search. Link URL to remove search.
+            linked_url = url.remove_query_params("order")
+
+        control = ColumnControl(
+            id=column_id,
+            text=name,
+            url=linked_url,
+            is_forward_sorted=column == column_id and not is_reverse,
+            is_reverse_sorted=column == column_id and is_reverse,
+        )
+        controls.append(control)
+    return controls

--- a/templates/table.html
+++ b/templates/table.html
@@ -45,7 +45,7 @@
           <thead>
             <tr>
               {% for control in column_controls %}
-              <th scope="col" {% if control.is_reverse %}class="dropup"{% endif %}>
+              <th scope="col" {% if control.is_reverse_sorted %}class="dropup"{% endif %}>
                 {% if control.url %}
                   <a {% if control.is_sorted %}class="dropdown-toggle"{% endif %} href="{{ control.url }}">
                 {% endif %}
@@ -63,12 +63,12 @@
           <tbody>
             {% for item in queryset %}
             <tr>
-              <th scope="row">{{ item[0] }}</th>
-              <td>{{ item[1] }}</td>
-              <td>{{ item[2] }}</td>
-              <td>{{ item[3] }}</td>
-              <td>{{ item[4] }}</td>
-              <td>{{ item[5] }}</td>
+              <th scope="row">{{ item.pk }}</th>
+              <td>{{ item.constituency }}</td>
+              <td>{{ item.surname }}</td>
+              <td>{{ item.first_name }}</td>
+              <td>{{ item.party }}</td>
+              <td>{{ item.votes }}</td>
             </tr>
             {% endfor %}
           </tbody>

--- a/tests/test_ordering.py
+++ b/tests/test_ordering.py
@@ -1,0 +1,167 @@
+from source.ordering import (
+    ColumnControl,
+    get_ordering,
+    sort_by_ordering,
+    get_column_controls,
+)
+from starlette.datastructures import URL
+from dataclasses import dataclass
+
+
+def test_order_by_column():
+    url = URL("?order=name")
+    allowed_column_ids = ["name", "email"]
+    order_column, order_reverse = get_ordering(
+        url=url, allowed_column_ids=allowed_column_ids
+    )
+    assert order_column == "name"
+    assert not order_reverse
+
+
+def test_order_by_reverse_column():
+    url = URL("?order=-name")
+    allowed_column_ids = ["name", "email"]
+    order_column, order_reverse = get_ordering(
+        url=url, allowed_column_ids=allowed_column_ids
+    )
+    assert order_column == "name"
+    assert order_reverse
+
+
+def test_order_by_invalid_column():
+    url = URL("?order=invalid")
+    allowed_column_ids = ["name", "email"]
+    order_column, order_reverse = get_ordering(
+        url=url, allowed_column_ids=allowed_column_ids
+    )
+    assert order_column is None
+    assert not order_reverse
+
+
+@dataclass
+class ExampleItem:
+    pk: int
+    username: str
+    email: str
+
+
+def test_sort_by_ordering():
+    queryset = [
+        ExampleItem(0, username="tom", email="tom@example.com"),
+        ExampleItem(1, username="lucy", email="lucy@example.com"),
+        ExampleItem(2, username="mia", email="mia@example.com"),
+    ]
+    sorted_queryset = sort_by_ordering(queryset, column="username", is_reverse=False)
+    assert sorted_queryset == [
+        ExampleItem(1, username="lucy", email="lucy@example.com"),
+        ExampleItem(2, username="mia", email="mia@example.com"),
+        ExampleItem(0, username="tom", email="tom@example.com"),
+    ]
+
+
+def test_sort_by_reverse_ordering():
+    queryset = [
+        ExampleItem(0, username="tom", email="tom@example.com"),
+        ExampleItem(1, username="lucy", email="lucy@example.com"),
+        ExampleItem(2, username="mia", email="mia@example.com"),
+    ]
+    sorted_queryset = sort_by_ordering(queryset, column="username", is_reverse=True)
+    assert sorted_queryset == [
+        ExampleItem(0, username="tom", email="tom@example.com"),
+        ExampleItem(2, username="mia", email="mia@example.com"),
+        ExampleItem(1, username="lucy", email="lucy@example.com"),
+    ]
+
+
+def test_sort_without_ordering():
+    queryset = [
+        ExampleItem(0, username="tom", email="tom@example.com"),
+        ExampleItem(1, username="lucy", email="lucy@example.com"),
+        ExampleItem(2, username="mia", email="mia@example.com"),
+    ]
+    sorted_queryset = sort_by_ordering(queryset, column=None, is_reverse=False)
+    assert sorted_queryset == [
+        ExampleItem(0, username="tom", email="tom@example.com"),
+        ExampleItem(1, username="lucy", email="lucy@example.com"),
+        ExampleItem(2, username="mia", email="mia@example.com"),
+    ]
+
+
+def test_get_column_controls_no_current_selection():
+    names = ["Username", "Email"]
+    url = URL("/")
+    column, is_reverse = None, False
+
+    controls = get_column_controls(url, names, column=None, is_reverse=False)
+
+    assert controls == [
+        ColumnControl(id="", text="#"),
+        ColumnControl(
+            id="username",
+            text="Username",
+            url=URL("/?order=username"),
+            is_forward_sorted=False,
+            is_reverse_sorted=False,
+        ),
+        ColumnControl(
+            id="email",
+            text="Email",
+            url=URL("/?order=email"),
+            is_forward_sorted=False,
+            is_reverse_sorted=False,
+        ),
+    ]
+
+
+def test_get_column_controls_forward_current_selection():
+    names = ["Username", "Email"]
+    url = URL("/?order=username")
+    column, is_reverse = "username", False
+
+    controls = get_column_controls(url, names, column="username", is_reverse=False)
+
+    assert controls == [
+        ColumnControl(id="", text="#"),
+        ColumnControl(
+            id="username",
+            text="Username",
+            url=URL("/?order=-username"),
+            is_forward_sorted=True,
+            is_reverse_sorted=False,
+        ),
+        ColumnControl(
+            id="email",
+            text="Email",
+            url=URL("/?order=email"),
+            is_forward_sorted=False,
+            is_reverse_sorted=False,
+        ),
+    ]
+
+
+def test_get_column_controls_reverse_current_selection():
+    names = ["Username", "Email"]
+    url = URL("/?order=-username")
+    column, is_reverse = "username", True
+
+    controls = get_column_controls(
+        url=url, names=names, column=column, is_reverse=is_reverse
+    )
+
+    assert controls == [
+        ColumnControl(id="", text="#"),
+        ColumnControl(
+            id="username",
+            text="Username",
+            url=URL("/"),
+            is_forward_sorted=False,
+            is_reverse_sorted=True,
+        ),
+        ColumnControl(
+            id="email",
+            text="Email",
+            url=URL("/?order=email"),
+            is_forward_sorted=False,
+            is_reverse_sorted=False,
+        ),
+    ]


### PR DESCRIPTION
Columns hyperlink to ordering-by-column.

Controls cycle through "forward sort", "reverse sort", "no sort" states.

![Screenshot 2019-10-03 at 14 53 28](https://user-images.githubusercontent.com/647359/66132834-96b58880-e5ed-11e9-8725-a2a5c824156e.png)
