### PR TITLE
Fix testing of virtualenv in scripts

### DIFF
--- a/scripts/lint
+++ b/scripts/lint
@@ -4,6 +4,6 @@ if [ -d "venv" ]; then
     BIN_PATH="venv/bin/"
 else
     BIN_PATH=""
-else
+fi
 
 ${BIN_PATH}black source tests "${@}"

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,9 +1,9 @@
 #!/bin/sh -ex
 
-if [ "${CONTINUOUS_INTEGRATION}" = "true" ]; then
+if [ -d "venv" ]; then
+    BIN_PATH="venv/bin/"
+else
     BIN_PATH=""
 else
-    BIN_PATH="venv/bin/"
-fi
 
 ${BIN_PATH}black source tests "${@}"

--- a/scripts/migration
+++ b/scripts/migration
@@ -1,9 +1,9 @@
 #!/bin/sh -ex
 
-if [ "${CONTINUOUS_INTEGRATION}" = "true" ]; then
+if [ -d "venv" ]; then
+    BIN_PATH="venv/bin/"
+else
     BIN_PATH=""
 else
-    BIN_PATH="venv/bin/"
-fi
 
 PYTHONPATH=. ${BIN_PATH}alembic "${@}"

--- a/scripts/migration
+++ b/scripts/migration
@@ -4,6 +4,6 @@ if [ -d "venv" ]; then
     BIN_PATH="venv/bin/"
 else
     BIN_PATH=""
-else
+fi
 
 PYTHONPATH=. ${BIN_PATH}alembic "${@}"

--- a/scripts/test
+++ b/scripts/test
@@ -1,10 +1,10 @@
 #!/bin/sh -ex
 
-if [ "${CONTINUOUS_INTEGRATION}" = "true" ]; then
+if [ -d "venv" ]; then
+    BIN_PATH="venv/bin/"
+else
     BIN_PATH=""
 else
-    BIN_PATH="venv/bin/"
-fi
 
 scripts/lint --check
 PYTHONPATH=. ${BIN_PATH}pytest tests -W ignore::DeprecationWarning --cov=source --cov=tests --cov-report=

--- a/scripts/test
+++ b/scripts/test
@@ -4,7 +4,7 @@ if [ -d "venv" ]; then
     BIN_PATH="venv/bin/"
 else
     BIN_PATH=""
-else
+fi
 
 scripts/lint --check
 PYTHONPATH=. ${BIN_PATH}pytest tests -W ignore::DeprecationWarning --cov=source --cov=tests --cov-report=


### PR DESCRIPTION
Virtualenv checking on `scripts/migration` was incorrect for the production case.
Switch around how we check if we're running with virtualenv or not.