### PR TITLE
Patch up Heroku DATABASE_URL to use 'postgresql' instead of 'postgres'

### DIFF
--- a/source/settings.py
+++ b/source/settings.py
@@ -11,6 +11,9 @@ DATABASE_URL = config(
     cast=databases.DatabaseURL,
     default="postgresql://localhost:5432/hostedapi",
 )
+if DATABASE_URL.dialect == 'postgres':
+    DATABASE_URL = DATABASE_URL.replace(dialect="postgresql")  # pragma: nocover
+
 TEST_DATABASE_URL = DATABASE_URL.replace(database="test_" + DATABASE_URL.database)
 
 

--- a/source/settings.py
+++ b/source/settings.py
@@ -11,7 +11,7 @@ DATABASE_URL = config(
     cast=databases.DatabaseURL,
     default="postgresql://localhost:5432/hostedapi",
 )
-if DATABASE_URL.dialect == 'postgres':
+if DATABASE_URL.dialect == "postgres":
     DATABASE_URL = DATABASE_URL.replace(dialect="postgresql")  # pragma: nocover
 
 TEST_DATABASE_URL = DATABASE_URL.replace(database="test_" + DATABASE_URL.database)


### PR DESCRIPTION
Heroku uses 'postgres' as the dialect in it's DATABASE_URL setting, but `databases` expects `postgresql`.

We'll just patch this up for now, but we ought to allow `databases` to work with either case.